### PR TITLE
Add RSpec.configuration.rspec_ssltls_https_proxy for global configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ describe 'www.example.com:443' do
 end
 ```
 
+You can also specify https_proxy server with `RSpec.configuration.rspec_ssltls_https_proxy`
+as global configuration.
+```
+RSpec.configuration.rspec_ssltls_https_proxy = 'http://proxy.example.com:3128'
+
+```
+or
+```
+RSpec.configuration.rspec_ssltls_https_proxy = ENV['https_proxy']
+```
+
 You can use followings for `support_protocol` and `support_cipher.protocol`:
 ```
  OpenSSL::SSL::SSLContext::METHODS

--- a/lib/rspec_ssltls.rb
+++ b/lib/rspec_ssltls.rb
@@ -3,6 +3,10 @@ require 'rspec/expectations'
 require 'socket'
 require 'openssl'
 
+RSpec.configure do |c|
+  c.add_setting :rspec_ssltls_https_proxy, default: nil
+end
+
 require 'rspec_ssltls/util'
 require 'rspec_ssltls/have_certificate'
 require 'rspec_ssltls/support_protocol'

--- a/lib/rspec_ssltls/util.rb
+++ b/lib/rspec_ssltls/util.rb
@@ -21,8 +21,9 @@ module RspecSsltls
     end
 
     def self.open_socket(uri, options = {})
-      if options[:proxy]
-        proxy_uri = build_uri(options[:proxy])
+      proxy = proxy_config(options)
+      if proxy
+        proxy_uri = build_uri(proxy)
         proxy_server = Net::SSH::Proxy::HTTP.new(proxy_uri.host,
                                                  proxy_uri.host,
                                                  user: proxy_uri.user,
@@ -31,6 +32,11 @@ module RspecSsltls
       else
         TCPSocket.open(uri.host, uri.port)
       end
+    end
+
+    def self.proxy_config(options = {})
+      options[:proxy] ? options[:proxy] :
+        RSpec.configuration.rspec_ssltls_https_proxy
     end
 
     def self.build_uri(source)
@@ -42,6 +48,7 @@ module RspecSsltls
       end
     end
 
+    private_class_method :proxy_config
     private_class_method :build_uri
   end
 end

--- a/spec/rspec_ssltls/util_spec.rb
+++ b/spec/rspec_ssltls/util_spec.rb
@@ -28,6 +28,19 @@ describe RspecSsltls::Util do
         socket = described_class.open_socket(uri, proxy: proxy_url)
         expect(socket).to eq(:direct)
       end
+      context 'when RSpec.configuration.rspec_ssltls_https_proxy is given' do
+        before :each do
+          RSpec.configuration.rspec_ssltls_https_proxy =
+            'http://proxy.example.com'
+        end
+        after :each do
+          RSpec.configuration.rspec_ssltls_https_proxy = nil
+        end
+        it 'should connect target via specified proxy server' do
+          socket = described_class.open_socket(uri, proxy: proxy_url)
+          expect(socket).to eq(:proxy)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Add following feature.

You can also specify https_proxy server with `RSpec.configuration.rspec_ssltls_https_proxy`
as global configuration.

```
RSpec.configuration.rspec_ssltls_https_proxy = 'http://proxy.example.com:3128'

```

or

```
RSpec.configuration.rspec_ssltls_https_proxy = ENV['https_proxy']
```
